### PR TITLE
Add Google Cloud Storage support

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 9fans.net/go v0.0.0-20181112161441-237454027057 h1:OcHlKWkAMJEF1ndWLGxp5dnJQkYM/YImUOvsBoz6h5E=
 9fans.net/go v0.0.0-20181112161441-237454027057/go.mod h1:diCsxrliIURU9xsYtjCp5AbpQKqdhKmf0ujWDUSkfoY=
+cloud.google.com/go v0.26.0 h1:e0WKqKTd5BnrG8aKH3J3h+QvEIQtSUcf2n5UZ5ZgLtQ=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 contrib.go.opencensus.io/exporter/ocagent v0.3.0 h1:fyqPXp7d+BBV3tXa7EE1CYrObJr7R9jTAOO/AsdcQBg=
 contrib.go.opencensus.io/exporter/ocagent v0.3.0/go.mod h1:0fnkYHF+ORKj7HWzOExKkUHeFX79gXSKUQbpnAM+wzo=
@@ -230,6 +231,7 @@ golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181011144130-49bb7cea24b1 h1:Y/KGZSOdz/2r0WJ9Mkmz6NJBusp0kiNx1Cn82lzJQ6w=
 golang.org/x/net v0.0.0-20181011144130-49bb7cea24b1/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be h1:vEDujvNQGv4jgYKudGeI/+DAX4Jffq6hpD55MmoEvKs=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/pkg/storage/config.go
+++ b/pkg/storage/config.go
@@ -2,15 +2,17 @@ package storage
 
 // Config represent a configuration for working with an object storage
 type Config struct {
-	Provider            string `mapstructure:"provider"`
-	AccessKey           string `mapstructure:"aws_access_key"`
-	SecretKey           string `mapstructure:"aws_secret_key"`
-	AzureStorageAccount string `mapstructure:"azure_storage_account"`
-	AzureStorageKey     string `mapstructure:"azure_storage_key"`
-	URL                 string `mapstructure:"url"`
-	Region              string `mapstructure:"region"`
-	BucketName          string `mapstructure:"bucketName"`
-	LocalPath           string `mapstructure:"path"`
+	Provider             string `mapstructure:"provider"`
+	AccessKey            string `mapstructure:"aws_access_key"`
+	SecretKey            string `mapstructure:"aws_secret_key"`
+	AzureStorageAccount  string `mapstructure:"azure_storage_account"`
+	AzureStorageKey      string `mapstructure:"azure_storage_key"`
+	GoogleServiceAccount string `mapstructure:"google_service_account"`
+	GoogleProjectId      string `mapstructure:"google_project_id"`
+	URL                  string `mapstructure:"url"`
+	Region               string `mapstructure:"region"`
+	BucketName           string `mapstructure:"bucketName"`
+	LocalPath            string `mapstructure:"path"`
 }
 
 // S3 is the configuration needed to save/open file from s3

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -201,7 +201,7 @@ func (store *Data) UploadFilesFromMemory(files map[string][]byte, dir string) er
 }
 
 func (store *Data) DownloadFilesToDirectory(files [][]string, localDir string, fromPath string, overwrite bool) error {
-	os.MkdirAll(localDir, os.ModeDir)
+	os.MkdirAll(localDir, 0750)
 	for _, fileSrcDst := range files {
 		local, remote := fileSrcDst[0], fileSrcDst[1]
 		file := filepath.Join(localDir, local)

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -25,10 +25,9 @@ import (
 
 	"github.com/graymeta/stow"
 	"github.com/graymeta/stow/azure"
+	"github.com/graymeta/stow/google"
 	"github.com/graymeta/stow/local"
 	"github.com/graymeta/stow/s3"
-	//  "github.com/graymeta/stow/google"
-	// "github.com/graymeta/stow/swift"
 )
 
 // Data represent where to put whatever you're downloading
@@ -66,19 +65,16 @@ func Init(cfg *Config) (*Data, error) {
 			azure.ConfigAccount: cfg.AzureStorageAccount,
 			azure.ConfigKey:     cfg.AzureStorageKey,
 		}
-	// case "google":
-	// 	config = stow.ConfigMap{
-	// 		google.ConfigJSON:      os.Getenv("GOOGLE_CLOUD_KEYFILE_JSON"),
-	// 		google.ConfigProjectId: os.Getenv("GOOGLE_PROJECT"),
-	// 		google.ConfigScopes:    "read-write",
-	// 	}
-	// case "swift":
-	// 	config = stow.ConfigMap{
-	// 		swift.ConfigUsername:      os.Getenv("OS_USERNAME"),
-	// 		swift.ConfigKey:           os.Getenv("OS_TOKEN"),
-	// 		swift.ConfigTenantName:    os.Getenv("OS_TENANT_NAME"),
-	// 		swift.ConfigTenantAuthURL: os.Getenv("OS_AUTH_URL"),
-	// 	}
+	case "google":
+		s.containerName = cfg.BucketName
+		sa, err := ioutil.ReadFile(cfg.GoogleServiceAccount)
+		if err != nil {
+			return nil, fmt.Errorf("Cannot read Google Service Account file %s: %v", cfg.GoogleServiceAccount, err)
+		}
+		config = stow.ConfigMap{
+			google.ConfigJSON:      string(sa),
+			google.ConfigProjectId: cfg.GoogleProjectId,
+		}
 	case "local":
 		config = stow.ConfigMap{
 			local.ConfigKeyPath: cfg.LocalPath,


### PR DESCRIPTION
The aim of this PR is to introduce support for Google Cloud Storage (GCS) as a backend for `furyagent`.

Summary of changes:
- added support for GCS
- removed commented code for Swift (I don't think we'll ever need it)
- fixed permissions of the directories created by `furyagent`

Since it is not possibile to mock the Google API, I've tested the changes by creating the needed resources using Terraform and correctly configured `furyagent` to use them.