### PR TITLE
Remove S3 struct dead code

### DIFF
--- a/pkg/storage/config.go
+++ b/pkg/storage/config.go
@@ -14,12 +14,3 @@ type Config struct {
 	BucketName           string `mapstructure:"bucketName"`
 	LocalPath            string `mapstructure:"path"`
 }
-
-// S3 is the configuration needed to save/open file from s3
-type S3 struct {
-	AccessKey  string `mapstructure:"aws_access_key"`
-	SecretKey  string `mapstructure:"aws_secret_key"`
-	URL        string `mapstructure:"url"`
-	Region     string `mapstructure:"region"`
-	BucketName string `mapstructure:"bucketName"`
-}


### PR DESCRIPTION
While documenting i found this piece of dead code. It is not used, was deprecated in favor of `Config` struct, in the same golang file.

